### PR TITLE
Adding GitHub logo and link to repo

### DIFF
--- a/public/api.html
+++ b/public/api.html
@@ -21,21 +21,31 @@
     integrity="sha256-77qGXu2p8NpfcBpTjw4jsMeQnz0vyh74f5do0cWjQ/Q=" crossorigin="anonymous" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.16.0/themes/prism-tomorrow.min.css"
     integrity="sha256-xevuwyBEb2ZYh4nDhj0g3Z/rDBnM569hg9Vq6gEw/Sg=" crossorigin="anonymous" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/material-design-iconic-font/2.2.0/css/material-design-iconic-font.min.css">
   <link rel="stylesheet" href="./assets/stylesheets/styles.css" />
 </head>
 
 <body>
-  <nav>
-    <div class="nav-wrapper">
-      <a href="/" class="branding">
-        <img class="logo" src="./assets/images/logo.svg" alt="WSF Logo" />
-        <span class="branding-copy">
-          <div class="copy-name">William S Fuller</div>
-          <div class="copy-title">Front End Engineer</div>
-        </span>
-      </a>
-    </div>
-  </nav>
+  <header>
+    <nav>
+      <div class="nav-wrapper">
+        <a href="/" class="branding">
+          <img class="logo" src="./assets/images/logo.svg" alt="WSF Logo" />
+          <span class="branding-copy">
+            <div class="copy-name">William S Fuller</div>
+            <div class="copy-title">Resume API</div>
+          </span>
+        </a>
+        <ul class="nav-links">
+          <li>
+            <a href="https://github.com/wsfuller/resume-api">
+              <i class="zmdi zmdi-github"></i>
+            </a>
+          </li>
+        </ul>
+      </div>
+    </nav>
+  </header>
   <main>
     <section>
       <div class="container">

--- a/public/assets/stylesheets/styles.css
+++ b/public/assets/stylesheets/styles.css
@@ -22,7 +22,9 @@ nav {
 
 .nav-wrapper {
   display: flex;
+  flex-direction: row;
   align-items: center;
+  justify-content: space-between;
   max-width: 1280px;
   width: 90%;
   margin: auto;
@@ -76,13 +78,13 @@ main {
   justify-content: center;
   position: absolute;
   z-index: 10;
-  background: rgba(0,0,0,0.75);
+  background: rgba(0, 0, 0, 0.75);
 }
 
 .overlay-title {
   padding: 0 16px;
   color: #ffffff;
-  color: rgba(255,255,255, 0.75);
+  color: rgba(255, 255, 255, 0.75);
   text-align: center;
 }
 
@@ -101,8 +103,8 @@ main {
 
 .api-results-error .error-icon {
   position: relative;
-  top: .25rem;
-  margin: 0 .5rem;
+  top: 0.25rem;
+  margin: 0 0.5rem;
 }
 
 .tool-logo {
@@ -142,7 +144,7 @@ footer .branding {
   color: #ffffff;
   text-decoration: none;
   opacity: 0.8;
-  transition: opacity .35s ease-in-out;
+  transition: opacity 0.35s ease-in-out;
 }
 
 footer .branding:hover {
@@ -156,9 +158,9 @@ footer .logo {
 }
 
 /* MATERIALIZE CSS OVERRIDES */
-pre[class*=language-] {
-    max-height: 50rem;
-    overflow-y: auto;
+pre[class*='language-'] {
+  max-height: 50rem;
+  overflow-y: auto;
 }
 
 .tabs {
@@ -166,12 +168,12 @@ pre[class*=language-] {
 }
 
 .tabs .tab a {
-color: rgba(255, 255, 255, 0.7);
+  color: rgba(255, 255, 255, 0.7);
 }
 
 .tabs .tab a:hover,
 .tabs .tab a.active {
-    color: #ffffff;
+  color: #ffffff;
 }
 
 .tabs .indicator {

--- a/public/index.html
+++ b/public/index.html
@@ -21,10 +21,12 @@
       integrity="sha256-77qGXu2p8NpfcBpTjw4jsMeQnz0vyh74f5do0cWjQ/Q=" crossorigin="anonymous" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.16.0/themes/prism-tomorrow.min.css"
       integrity="sha256-xevuwyBEb2ZYh4nDhj0g3Z/rDBnM569hg9Vq6gEw/Sg=" crossorigin="anonymous" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/material-design-iconic-font/2.2.0/css/material-design-iconic-font.min.css">
     <link rel="stylesheet" href="./assets/stylesheets/styles.css" />
   </head>
+
   <body>
-    <main>
+    <header>
       <nav>
         <div class="nav-wrapper">
           <a href="/" class="branding">
@@ -34,9 +36,17 @@
               <div class="copy-title">Resume API</div>
             </span>
           </a>
+          <ul class="nav-links">
+            <li>
+              <a href="https://github.com/wsfuller/resume-api">
+                <i class="zmdi zmdi-github"></i>
+              </a>
+            </li>
+          </ul>
         </div>
       </nav>
-
+    </header>
+    <main>
       <div class="hero">
         <div class="hero-overlay">
           <h1 class="overlay-title">


### PR DESCRIPTION
Addresses issue #1 by adding a link to this repo

- Link added to navbar
- Link out to [zmdi material design icons](https://zavoloklom.github.io/material-design-iconic-font/icons.html)
- Updated HTML semantics on both index and api pages to now have the follow:
```
<body>
  <header>
    <nav>...</nav>
  </header>
  <main>...</main>
</body>
```